### PR TITLE
Add conversion support for gif extensions

### DIFF
--- a/projects/giflib/ProtoToGif.cpp
+++ b/projects/giflib/ProtoToGif.cpp
@@ -48,17 +48,6 @@ void ProtoConverter::visit(GlobalColorTable const& gct)
 	m_output.write(gct.colors().data(), gct.colors().size());
 }
 
-void ProtoConverter::visit(LocalColorTable const& lct)
-{
-	// TODO: This has to contain exactly 3*2^(m_LocalColorExp + 1) bytes
-	m_output.write(lct.colors().data(), lct.colors().size());
-}
-
-void ProtoConverter::visit(BasicChunk const& chunk)
-{
-	writeBasicChunk(chunk);
-}
-
 void ProtoConverter::visit(GraphicControlExtension const&)
 {
 }
@@ -69,71 +58,55 @@ void ProtoConverter::visit(ImageChunk const& chunk)
 	switch (chunk.chunk_oneof_case())
 	{
 		case ImageChunk::kBasic:
-			writeBasicChunk(chunk.basic());
+			visit(chunk.basic());
 			break;
 		case ImageChunk::kPlaintext:
+			visit(chunk.plaintext());
 			break;
 		case ImageChunk::kAppExt:
+			visit(chunk.appext());
 			break;
 		case ImageChunk::kComExt:
+			visit(chunk.comext());
 			break;
 		case ImageChunk::CHUNK_ONEOF_NOT_SET:
 			break;
 	}
 }
 
-void ProtoConverter::visit(PlainTextChunk const&)
+void ProtoConverter::visit(const BasicChunk &chunk)
 {
-
+	// TODO: Convert graphic control extension
+	visit(chunk.imdescriptor());
+	if(m_hasLCT)
+		visit(chunk.lct());
+	visit(chunk.img());
 }
 
-void ProtoConverter::visit(CommentExtension const&)
+void ProtoConverter::visit(LocalColorTable const& lct)
 {
-
+	// TODO: This has to contain exactly 3*2^(m_LocalColorExp + 1) bytes
+	m_output.write(lct.colors().data(), lct.colors().size());
 }
 
-void ProtoConverter::visit(ApplicationExtension const&)
+void ProtoConverter::visit(ImageDescriptor const& descriptor)
 {
-
-}
-
-void ProtoConverter::visit(Trailer const&)
-{
-	writeByte(0x3B);
-}
-
-void ProtoConverter::writeByte(uint8_t x)
-{
-	m_output.write((char *)&x, sizeof(x));
-}
-
-void ProtoConverter::writeWord(uint16_t x)
-{
-	x = __builtin_bswap16(x);
-	m_output.write((char *)&x, sizeof(x));
-}
-
-void ProtoConverter::writeInt(uint32_t x)
-{
-	x = __builtin_bswap32(x);
-	m_output.write((char *)&x, sizeof(x));
-}
-
-uint16_t ProtoConverter::extractWordFromUInt32(uint32_t a)
-{
-	uint16_t first_byte = (a & 0xFF);
-	uint16_t second_byte = ((a >> 8) & 0xFF) << 8;
-	return first_byte | second_byte;
-}
-
-uint8_t ProtoConverter::extractByteFromUInt32(uint32_t a)
-{
-	uint8_t byte = a & 0x80;
-	return byte;
+	// TODO: Remove seperator from proto since it is always 2C
+	writeByte(0x2C);
+	writeWord(extractWordFromUInt32(descriptor.left()));
+	writeWord(extractWordFromUInt32(descriptor.top()));
+	writeWord(extractWordFromUInt32(descriptor.height()));
+	writeWord(extractWordFromUInt32(descriptor.width()));
+	uint8_t packedByte = extractByteFromUInt32(descriptor.packed());
+	if (packedByte & 0x80) {
+		m_hasLCT = true;
+		m_localColorExp = packedByte & 0x07;
+	}
 }
 
 void ProtoConverter::visit(SubBlock const& block)
 {
+	// TODO: Write as many bytes as len
 	uint8_t len = extractByteFromUInt32(block.len());
 	if (len == 0)
 		writeByte(0x00);
@@ -153,26 +126,90 @@ void ProtoConverter::visit(ImageData const& img)
 	writeByte(0x00);
 }
 
-void ProtoConverter::writeBasicChunk(const BasicChunk &chunk)
+void ProtoConverter::visit(PlainTextExtension const& ptExt)
 {
-	// TODO: Convert graphic control extension
-	visit(chunk.imdescriptor());
-	if(m_hasLCT)
-		visit(chunk.lct());
-	visit(chunk.img());
+	// First two bytes are 0x21 0x01
+	writeByte(0x21);
+	writeByte(0x01);
+	// Skip zero bytes
+	writeByte(0x00);
+	for (auto const& block: ptExt.subs())
+		visit(block);
+	// NULL sub block signals end
+	writeByte(0x00);
 }
 
-void ProtoConverter::visit(ImageDescriptor const& descriptor)
+void ProtoConverter::visit(CommentExtension const& comExt)
 {
-	// TODO: Remove seperator from proto since it is always 2C
-	writeByte(0x2C);
-	writeWord(extractWordFromUInt32(descriptor.left()));
-	writeWord(extractWordFromUInt32(descriptor.top()));
-	writeWord(extractWordFromUInt32(descriptor.height()));
-	writeWord(extractWordFromUInt32(descriptor.width()));
-	uint8_t packedByte = extractByteFromUInt32(descriptor.packed());
-	if (packedByte & 0x80) {
-		m_hasLCT = true;
-		m_localColorExp = packedByte & 0x07;
-	}
+	// First two bytes are 0x21 0xFE
+	writeByte(0x21);
+	writeByte(0xFE);
+	// Sub-blocks
+	for (auto const& block: comExt.subs())
+		visit(block);
+	// NULL sub block signals end of image data
+	writeByte(0x00);
+}
+
+void ProtoConverter::visit(ApplicationExtension const& appExt)
+{
+	// First two bytes are 0x21 0xFF
+	writeByte(0x21);
+	writeByte(0xFF);
+	// Next, we write "11" decimal or 0x0B
+	writeByte(0x0B);
+	writeLong(appExt.appid());
+	// We hardcode the auth code to 1.0 or 0x31 0x2E 0x30
+	writeByte(0x31);
+	writeByte(0x2E);
+	writeByte(0x30);
+	// Sub-blocks
+	for (auto const& block: appExt.subs())
+		visit(block);
+	// NULL sub block signals end of image data
+	writeByte(0x00);
+}
+
+void ProtoConverter::visit(Trailer const&)
+{
+	writeByte(0x3B);
+}
+
+// =============================================================
+// Utility functions
+// =============================================================
+void ProtoConverter::writeByte(uint8_t x)
+{
+	m_output.write((char *)&x, sizeof(x));
+}
+
+void ProtoConverter::writeWord(uint16_t x)
+{
+	x = __builtin_bswap16(x);
+	m_output.write((char *)&x, sizeof(x));
+}
+
+void ProtoConverter::writeInt(uint32_t x)
+{
+	x = __builtin_bswap32(x);
+	m_output.write((char *)&x, sizeof(x));
+}
+
+void ProtoConverter::writeLong(uint64_t x)
+{
+	x = __builtin_bswap64(x);
+	m_output.write((char *)&x, sizeof(x));
+}
+
+uint16_t ProtoConverter::extractWordFromUInt32(uint32_t a)
+{
+	uint16_t first_byte = (a & 0xFF);
+	uint16_t second_byte = ((a >> 8) & 0xFF) << 8;
+	return first_byte | second_byte;
+}
+
+uint8_t ProtoConverter::extractByteFromUInt32(uint32_t a)
+{
+	uint8_t byte = a & 0x80;
+	return byte;
 }

--- a/projects/giflib/ProtoToGif.cpp
+++ b/projects/giflib/ProtoToGif.cpp
@@ -45,6 +45,7 @@ void ProtoConverter::visit(LogicalScreenDescriptor const& lsd)
 void ProtoConverter::visit(GlobalColorTable const& gct)
 {
 	// TODO: This has to contain exactly 3*2^(m_GlobalColorExp + 1) bytes
+	// IMPORTANT
 	m_output.write(gct.colors().data(), gct.colors().size());
 }
 
@@ -54,7 +55,6 @@ void ProtoConverter::visit(GraphicControlExtension const&)
 
 void ProtoConverter::visit(ImageChunk const& chunk)
 {
-	// TODO: Implement converters for different chunk types
 	switch (chunk.chunk_oneof_case())
 	{
 		case ImageChunk::kBasic:
@@ -86,6 +86,7 @@ void ProtoConverter::visit(const BasicChunk &chunk)
 void ProtoConverter::visit(LocalColorTable const& lct)
 {
 	// TODO: This has to contain exactly 3*2^(m_LocalColorExp + 1) bytes
+	// IMPORTANT
 	m_output.write(lct.colors().data(), lct.colors().size());
 }
 
@@ -106,7 +107,7 @@ void ProtoConverter::visit(ImageDescriptor const& descriptor)
 
 void ProtoConverter::visit(SubBlock const& block)
 {
-	// TODO: Write as many bytes as len
+	// TODO: Write as many bytes as len (IMPORTANT)
 	uint8_t len = extractByteFromUInt32(block.len());
 	if (len == 0)
 		writeByte(0x00);

--- a/projects/giflib/ProtoToGif.h
+++ b/projects/giflib/ProtoToGif.h
@@ -21,7 +21,7 @@ namespace gifProtoFuzzer {
 		void visit(const ImageDescriptor&);
 		void visit(const LocalColorTable&);
 		void visit(const GraphicControlExtension&);
-		void visit(const PlainTextChunk&);
+		void visit(const PlainTextExtension&);
 		void visit(const ApplicationExtension&);
 		void visit(const CommentExtension&);
 		void visit(const Trailer&);
@@ -30,8 +30,7 @@ namespace gifProtoFuzzer {
 		void writeByte(uint8_t x);
 		void writeWord(uint16_t x);
 		void writeInt(uint32_t x);
-		void writeChunk(const ImageChunk &chunk);
-		void writeBasicChunk(const BasicChunk &chunk);
+		void writeLong(uint64_t x);
 		static uint16_t extractWordFromUInt32(uint32_t a);
 		static uint8_t extractByteFromUInt32(uint32_t a);
 

--- a/projects/giflib/gif_fuzz_proto.proto
+++ b/projects/giflib/gif_fuzz_proto.proto
@@ -3,7 +3,7 @@ syntax = "proto2";
 // Refer to: https://www.fileformat.info/format/gif/egff.htm
 // https://www.matthewflickinger.com/lab/whatsinagif/bits_and_bytes.asp
 
-// TODO: Desribe messages included as empty stubs
+// TODO: Verify if this is correct
 
 message LogicalScreenDescriptor {
     required uint32 ScreenWidth = 1;
@@ -26,19 +26,11 @@ message ImageDescriptor {
   required uint32 Packed = 6;
 }
 
-message ImageChunk {
-  oneof chunk_oneof {
-    BasicChunk basic = 1;
-    PlainTextChunk plaintext = 2;
-    ApplicationExtension appExt = 3;
-    CommentExtension comExt = 4;
-  }
-}
-
 message GraphicControlExtension {
 }
 
 message PlainTextExtension {
+  repeated SubBlock subs = 1;
 }
 
 message LocalColorTable {
@@ -62,22 +54,26 @@ message BasicChunk {
   optional GraphicControlExtension gcExt = 4;
 }
 
-message PlainTextChunk {
-  optional GraphicControlExtension gcExt = 1;
-  required PlainTextExtension ptExt = 2;
-}
-
 message ApplicationExtension {
-
+  required fixed64 appid = 1;
+  repeated SubBlock subs = 2;
 }
 
 message CommentExtension {
-
+  repeated SubBlock subs = 1;
 }
 
-// Stubs
 message Header {}
 message Trailer {}
+
+message ImageChunk {
+  oneof chunk_oneof {
+    BasicChunk basic = 1;
+    PlainTextExtension plaintext = 2;
+    ApplicationExtension appExt = 3;
+    CommentExtension comExt = 4;
+  }
+}
 
 message GifProto {
   required Header header = 1;


### PR DESCRIPTION
This PR
  - adds support for converting plain text, comment, and application extensions
  - flags important TODOs in comments

@viniul here are some pending TODOs
  - at a high level, obtain and compare line coverage of vanilla and proto-based giflib fuzzers (this will hopefully support our claim that protobuf is an improvement). My initial feeling is that we should be able to beat the coverage of vanilla fuzzer that we made upstream with this proto version
  - take a look at TODOs marked IMPORTANT in the source file
    - essentially, we need a way to write only as many bytes as necessary (not more not less) 